### PR TITLE
Added support for Ubuntu 18.04 and greater

### DIFF
--- a/Modules/01. Introduction/Lab-Introduction.md
+++ b/Modules/01. Introduction/Lab-Introduction.md
@@ -40,7 +40,7 @@
      - `man tree`
      - **For Ubuntu versions 18.04 and greater:** 
         - `sudo snap install tree`
-        - `tree --help`
+        - `tree --help` 
      - Take a screenshot and add to `lab01.md`
 
 1. **Regex**

--- a/Modules/01. Introduction/Lab-Introduction.md
+++ b/Modules/01. Introduction/Lab-Introduction.md
@@ -38,6 +38,9 @@
      - On linux: `sudo apt-get install tree`, or use the Ubuntu software install
      - on OSX: `brew install tree`
      - `man tree`
+     - **For Ubuntu versions 18.04 and greater:** 
+        - `sudo snap install tree`
+        - `tree --help`
      - Take a screenshot and add to `lab01.md`
 
 1. **Regex**


### PR DESCRIPTION
With version 18.04 Ubuntu switched to using snap for installing packages including tree.  Additionally there is currently a bug preventing man tree from working( seen `[here](https://bugs.launchpad.net/snapd/+bug/1575593)`) so instead use --help.